### PR TITLE
Fix for deleteAction

### DIFF
--- a/doc/book/getting-started/forms-and-actions.md
+++ b/doc/book/getting-started/forms-and-actions.md
@@ -625,7 +625,7 @@ Let's start with the action code in `AlbumController::deleteAction()`:
 
             if ($del == 'Yes') {
                 $id = (int) $request->getPost('id');
-                $this->getAlbumTable()->deleteAlbum($id);
+                $this->table->deleteAlbum($id);
             }
 
             // Redirect to list of albums
@@ -634,7 +634,7 @@ Let's start with the action code in `AlbumController::deleteAction()`:
 
         return array(
             'id'    => $id,
-            'album' => $this->getAlbumTable()->getAlbum($id)
+            'album' => $this->table->getAlbum($id)
         );
     }
 //...


### PR DESCRIPTION
Fix for "A plugin by the name "getAlbumTable" was not found in the plugin manager Zend\Mvc\Controller\PluginManager"
In new tutorial the getAlbumTable was replaced with $this->table
