### PR TITLE
Added hints for running PHPUnit on Windows.

### DIFF
--- a/doc/book/unit-testing.md
+++ b/doc/book/unit-testing.md
@@ -43,6 +43,12 @@ installed, you can run these:
 $ ./vendor/bin/phpunit
 ```
 
+> On Windows you need to wrap the command in double quotes:
+> 
+> ```bash
+> $ "vendor/bin/phpunit"
+> ```
+
 You should see output similar to the following:
 
 ```text
@@ -117,8 +123,19 @@ test suite to it. When done, it should read as follows:
 </phpunit>
 ```
 
-Now run `phpunit -- testsuite Album` from the project root; you should get
-similar output to the following:
+Now you can run your new Album test suite from the project root:
+
+```bash
+$ "vendor/bin/phpunit" --testsuite Album
+```
+
+> On Windows don't forget to wrap the phpunit command in double quotes:
+> 
+> ```bash
+> $ "vendor/bin/phpunit" --testsuite Album
+> ```
+
+You should get similar output to the following:
 
 ```text
 PHPUnit 5.3.4 by Sebastian Bergmann and contributors.


### PR DESCRIPTION
If trying to run PHPUnit on Windows as mentioned in the tutorial it doesn't work, you also can't run PHPUnit globally without further setup. However wrapping the command in double quotes fixes this and runs PHPUnit from the composer bin directory.

This may be obvious to some who are used to the command line however as this is part of the Getting Started tutorial I think it is worth mentioning.
