### PR TITLE
Fix non existing FQN Model\AlbumTableGateway::class reference

### DIFF
--- a/doc/book/getting-started/database-and-models.md
+++ b/doc/book/getting-started/database-and-models.md
@@ -217,10 +217,10 @@ class Module implements ConfigProviderInterface
         return [
             'factories' => [
                 Model\AlbumTable::class =>  function($container) {
-                    $tableGateway = $container->get(Model\AlbumTableGateway::class);
+                    $tableGateway = $container->get('Model\AlbumTableGateway');
                     return new Model\AlbumTable($tableGateway);
                 },
-                Model\AlbumTableGateway::class => function ($container) {
+                'Model\AlbumTableGateway' => function ($container) {
                     $dbAdapter = $container->get(AdapterInterface::class);
                     $resultSetPrototype = new ResultSet();
                     $resultSetPrototype->setArrayObjectPrototype(new Model\Album());
@@ -258,7 +258,7 @@ for more details.
 > - You can extend the factory if desired.
 > - You can re-use the factory across multiple instances that have related
 >   construction.
-> 
+>
 > Creating factories is covered in the [zend-servicemanager documentation](https://zendframework.github.io/zend-servicemanager/configuring-the-service-manager/#factories).
 
 The `Zend\Db\Adapter\AdapterInterface` service is registered by the zend-db
@@ -485,7 +485,7 @@ links.
 > We always use the `escapeHtml()` view helper to help protect ourselves from
 > [Cross Site Scripting (XSS) vulnerabilities](http://en.wikipedia.org/wiki/Cross-site_scripting).
 
-If you open `http://localhost:8080/album` (or `http://zf2-tutorial.localhost/album` 
+If you open `http://localhost:8080/album` (or `http://zf2-tutorial.localhost/album`
 if you are using self-hosted Apache) you should see this:
 
 ![Initial album listing](../images/user-guide.database-and-models.album-list.png)


### PR DESCRIPTION
There is no `Model\AlbumTableGateway` class at that point in the tutorial so a string must be used.
