### PR TITLE
Remove duplicate getArrayCopy method

### DIFF
--- a/doc/book/getting-started/forms-and-actions.md
+++ b/doc/book/getting-started/forms-and-actions.md
@@ -102,15 +102,6 @@ class Album implements InputFilterAwareInterface
         $this->title  = ! empty($data['title']) ? $data['title'] : null;
     }
 
-    public function getArrayCopy()
-    {
-        return [
-            'id'     => $this->id,
-            'artist' => $this->artist,
-            'title'  => $this->title,
-        ];
-    }
-
     /* Add the following methods: */
 
     public function setInputFilter(InputFilterInterface $inputFilter)


### PR DESCRIPTION
The `getArrayCopy` method is added during the edit album phase and is not needed buy the add album action.
