### PR TITLE
Fix including module.config.php

### DIFF
--- a/doc/book/getting-started/modules.md
+++ b/doc/book/getting-started/modules.md
@@ -54,7 +54,7 @@ class Module implements ConfigProviderInterface
 {
     public function getConfig()
     {
-        return include __DIR__ . '/../config/module.config.php';
+        return include __DIR__ . '/config/module.config.php';
     }
 }
 ```


### PR DESCRIPTION
The `module.config.php`cannot be found. This causes an exception:

> Uncaught Zend\ModuleManager\Listener\Exception\InvalidArgumentException: Config being merged    must be an array, implement the Traversable interface, or be an instance of Zend\Config\Config. boolean given.
