### PR TITLE
getArrayCopy() magically appearing...too soon

### DIFF
--- a/doc/book/getting-started/forms-and-actions.md
+++ b/doc/book/getting-started/forms-and-actions.md
@@ -106,15 +106,6 @@ class Album implements InputFilterAwareInterface
         $this->title  = !empty($data['title']) ? $data['title'] : null;
     }
 
-    public function getArrayCopy()
-    {
-        return [
-            'id'     => $this->id,
-            'artist' => $this->artist,
-            'title'  => $this->title,
-        ];
-    }
-
     /* Add the following methods: */
 
     public function setInputFilter(InputFilterInterface $inputFilter)


### PR DESCRIPTION
The `getArrayCopy()` method is magically appearing all of a sudden with no mention that we should add it at that point. Adding it isn't until later.
