### PR TITLE
Remove dispatch() method parameter

### DIFF
--- a/doc/book/unit-testing.md
+++ b/doc/book/unit-testing.md
@@ -427,7 +427,7 @@ public function testIndexActionCanBeAccessed()
 {
     $this->albumTable->fetchAll()->willReturn([]);
 
-    $this->dispatch('/album', 'GET');
+    $this->dispatch('/album');
     $this->assertResponseStatusCode(200);
     $this->assertModuleName('Album');
     $this->assertControllerName(AlbumController::class);


### PR DESCRIPTION
The method is set to the default `get` all of a sudden. Let's not introduce unneeded differences with previous code.
