### PR TITLE
Issue #56: missing minimal configuration for `Zend\Db`

### DIFF
--- a/doc/book/getting-started/skeleton-application.md
+++ b/doc/book/getting-started/skeleton-application.md
@@ -118,19 +118,18 @@ prompts that you may not want to enable by default is `Zend\Test`.)
 Once the installation is done, the skeleton installer removes itself, and the
 new application is ready to start!
 
-> ### Small DB configuration
->
-> When you have chosen "y" for database support with 'Zend\Db', you need to create a minimal database configuration in `config/autoload/global.php`. In [Database and models](/tutorials/getting-started/database-and-models) chapter we will explain more about this configuration, but for now it's enough to just add the following.
-> 
-> ```php
-> return [
->      'db' => [
->          'driver' => 'Pdo',
->          'dsn' => 'sqlite::memory:',
->      ],
->  ];
-> ```
-> 
+### Small DB configuration
+
+When you have chosen "y" for database support with 'Zend\Db', you need to create a minimal database configuration in `config/autoload/global.php`. In [Database and models](/tutorials/getting-started/database-and-models) chapter we will explain more about this configuration, but for now it's enough to just add the following.
+
+```php
+return [
+    'db' => [
+        'driver' => 'Pdo',
+        'dsn' => 'sqlite::memory:',
+    ],
+];
+```
 
 > ### Downloading the skeleton
 >

--- a/doc/book/getting-started/skeleton-application.md
+++ b/doc/book/getting-started/skeleton-application.md
@@ -118,6 +118,20 @@ prompts that you may not want to enable by default is `Zend\Test`.)
 Once the installation is done, the skeleton installer removes itself, and the
 new application is ready to start!
 
+> ### Small DB configuration
+>
+> When you have chosen "y" for database support with 'Zend\Db', you need to create a minimal database configuration in `config/autoload/global.php`. In [Database and models](/tutorials/getting-started/database-and-models) chapter we will explain more about this configuration, but for now it's enough to just add the following.
+> 
+> ```php
+> return [
+>      'db' => [
+>          'driver' => 'Pdo',
+>          'dsn' => 'sqlite::memory:',
+>      ],
+>  ];
+> ```
+> 
+
 > ### Downloading the skeleton
 >
 > Another way to install the ZendSkeletonApplication is to use github to


### PR DESCRIPTION
I added a few lines for people new to the framework to at least have a minimal db configuration to launch the ZF application without errors.
