### PR TITLE
zend-db-sql-zend-hydrator.md - error in line 39

### DIFF
--- a/doc/book/in-depth-guide/zend-db-sql-zend-hydrator.md
+++ b/doc/book/in-depth-guide/zend-db-sql-zend-hydrator.md
@@ -36,7 +36,7 @@ following script in `data/load_posts.php`:
 
 ```php
 <?php
-$db = new PDO('sqlite:' . realpath(__DIR__) . 'zftutorial.db');
+$db = new PDO('sqlite:' . realpath(__DIR__) . '/zftutorial.db');
 $fh = fopen(__DIR__ . '/posts.schema.sql', 'r');
 while ($line = fread($fh, 4096)) {
     $line = trim($line);


### PR DESCRIPTION
the command:
$db = new PDO('sqlite:' . realpath(**DIR**) . 'zftutorial.db');
it should be
$db = new PDO('sqlite:' . realpath(**DIR**) . '/zftutorial.db');
otherwise it does not work.
creates a  file datazftutorial.db in the root of the project.
