### PR TITLE
use AdapterInterface instead of Adapter

### DIFF
--- a/doc/book/getting-started/database-and-models.md
+++ b/doc/book/getting-started/database-and-models.md
@@ -349,14 +349,14 @@ create it in our `Module` class, only this time, under a new method,
 ```php
 namespace Album;
 
-use Zend\Db\Adapter\Adapter;
+use Zend\Db\Adapter\AdapterInterface;
 use Zend\Db\ResultSet\ResultSet;
 use Zend\Db\TableGateway\TableGateway;
 use Zend\ModuleManager\Feature\ConfigProviderInterface;
 
 class Module implements ConfigProviderInterface
 {
-    // getConfig() and getServiceConfig methods are here
+    // getConfig() and getServiceConfig() methods are here
 
     // Add this method:
     public function getControllerConfig()


### PR DESCRIPTION
I was working through the tutorial (as a ZF newbie) and found I had to replace Adapter with AdapterInterface; otherwise a fatal error was thrown previewing the `/album/` page in the browser.
Still, Eclipse tells me: `AlbumTableGateway cannot be resolved to a type` but PHP does not report any issue in this regard. Well, there is no class `AlbumTableGateway` but obviously `::class` is allowed to be used on non-existing classes so Eclipse is wrong here displaying an error instead of a warning.