### PR TITLE
phpunit now namespaced

### DIFF
--- a/doc/book/unit-testing.md
+++ b/doc/book/unit-testing.md
@@ -545,7 +545,7 @@ with the following contents:
 namespace AlbumTest\Model;
 
 use Album\Model\Album;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 class AlbumTest extends TestCase
 {
@@ -677,7 +677,7 @@ namespace AlbumTest\Model;
 
 use Album\Model\AlbumTable;
 use Album\Model\Album;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use RuntimeException;
 use Zend\Db\ResultSet\ResultSetInterface;
 use Zend\Db\TableGateway\TableGatewayInterface;

--- a/doc/book/unit-testing.md
+++ b/doc/book/unit-testing.md
@@ -545,7 +545,7 @@ with the following contents:
 namespace AlbumTest\Model;
 
 use Album\Model\Album;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 class AlbumTest extends TestCase
 {
@@ -677,7 +677,7 @@ namespace AlbumTest\Model;
 
 use Album\Model\AlbumTable;
 use Album\Model\Album;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Zend\Db\ResultSet\ResultSetInterface;
 use Zend\Db\TableGateway\TableGatewayInterface;


### PR DESCRIPTION
After updating phpunit to version 6 or greater released on 2017-02-03 (e.g. with composer), phpunit code is now namespaced.  Hence the lines
    use PHPUnit_Framework_TestCase as TestCase;
needs to be changed to 
    use PHPUnit\Framework\TestCase as TestCase;