### PR TITLE
setExpectedException deprecated?

### DIFF
--- a/doc/book/unit-testing.md
+++ b/doc/book/unit-testing.md
@@ -766,10 +766,8 @@ public function testExceptionIsThrownWhenGettingNonExistentAlbum()
         ->select(['id' => 123])
         ->willReturn($resultSet->reveal());
 
-    $this->setExpectedException(
-        RuntimeException::class,
-        'Could not find row with identifier 123'
-    );
+    $this->expectException (RuntimeException::class);
+    $this->expectExceptionMessage('Could not find row with identifier 123');
     $this->albumTable->getAlbum(123);
 }
 ```

--- a/doc/book/unit-testing.md
+++ b/doc/book/unit-testing.md
@@ -766,7 +766,7 @@ public function testExceptionIsThrownWhenGettingNonExistentAlbum()
         ->select(['id' => 123])
         ->willReturn($resultSet->reveal());
 
-    $this->expectException (RuntimeException::class);
+    $this->expectException(RuntimeException::class);
     $this->expectExceptionMessage('Could not find row with identifier 123');
     $this->albumTable->getAlbum(123);
 }


### PR DESCRIPTION
setExpectedException didn't work for me, but when I made the suggested change it worked fine.
Based on https://github.com/Roave/BetterReflection/issues/170